### PR TITLE
Improve Discord icon visualization

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -7,7 +7,7 @@ const { className } = Astro.props;
 
 <article
   data-glow
-  class={`group  text-[#E2E2E2] blur-effect border-2 border-[#3D2D42] relative rounded-[24px] h-full ${className}`}
+  class={`group text-[#E2E2E2] blur-effect border-2 border-[#3D2D42] relative rounded-[24px] h-full overflow-hidden ${className}`}
 >
   <div data-glow></div>
   <slot />
@@ -17,7 +17,7 @@ const { className } = Astro.props;
   .blur-effect {
     background: hsla(286, 58%, 16%, 0.28);
     backdrop-filter: blur(3px);
-    border-radius: 1rem;
+    border-radius: 24px;
     box-shadow:
       0 8px 16px 0 rgba(255, 100, 69, 0),
       0 2px 10px 2px rgba(0, 0, 0, 0.2),

--- a/src/components/social/Discord.astro
+++ b/src/components/social/Discord.astro
@@ -6,7 +6,7 @@ import CustomArrow from "../CustomArrow.astro";
   <img
     class="absolute right-0 top-3 m-auto"
     src="svgs/discord.svg"
-    width="200px"
+    width="180px"
   />
 
   <div class="relative group z-20 flex h-full items-end">

--- a/src/components/social/Discord.astro
+++ b/src/components/social/Discord.astro
@@ -4,14 +4,11 @@ import CustomArrow from "../CustomArrow.astro";
 
 <a href="https://discord.com/invite/comuafor" target="_blank">
   <img
-    class="absolute right-0 top-0 bottom-20 m-auto"
+    class="absolute right-0 top-3 m-auto"
     src="svgs/discord.svg"
     width="200px"
   />
-  <div
-    class="absolute w-[200px] right-0 top-0 bottom-20 m-auto bg-gradient-to-b from-transparent to-[#0403038f]"
-  >
-  </div>
+
   <div class="relative group z-20 flex h-full items-end">
     <div class="flex gap-x-2 items-center">
       <p class="text-[#E2E2E2] hover:text-white text-4xl">ComuAfor</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ import Card from "@/components/Card.astro";
       <Twitch />
     </Card>
     <!-- <TwitchStatus client:load /> -->
-    <Card className="circle row-span-2 col-span-3 p-6">
+    <Card className="circle row-span-2 col-span-3 p-6 min-h-[200px]">
       <Discord />
     </Card>
     <Card className="circle col-span-5">


### PR DESCRIPTION
- modified width and absolute to the discord position
- add overflow-hidden to the Card component
- Add min-h to the Discord component
- 
<img width="533" alt="image" src="https://github.com/afordigital/linktree/assets/62910118/6a570356-0dac-4675-8b51-76019b310a30">
