### PR TITLE
Update README.md: Modificación de link de Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ All commands are run from the root of the project, from a terminal:
 
 ## Deployment
 
-Vercel: [Linktree](https://aforcado.vercel.app)
+Vercel: [Linktree](https://www.afor.digital/)


### PR DESCRIPTION
Modificación del Link de Deployment, porque redirigía al usuario a la app de Aforcado (https://aforcado.vercel.app/) en vez redirigir al Linktree (https://www.afor.digital/)