### PR TITLE
fix: correct discord icon overflow

### DIFF
--- a/src/components/social/Discord.astro
+++ b/src/components/social/Discord.astro
@@ -3,11 +3,13 @@ import CustomArrow from "../CustomArrow.astro";
 ---
 
 <a href="https://discord.com/invite/comuafor" target="_blank">
-  <img
-    class="absolute right-0 top-3 m-auto"
-    src="svgs/discord.svg"
-    width="180px"
-  />
+  <div class='absolute top-0 right-0 w-full h-full rounded-[24px] overflow-hidden'>
+    <img
+      class='absolute right-0 top-3'
+      src="svgs/discord.svg"
+      width="180px"
+    />
+  </div>
 
   <div class="relative group z-20 flex h-full items-end">
     <div class="flex gap-x-2 items-center">


### PR DESCRIPTION
![Captura de pantalla 2024-05-24 153556](https://github.com/afordigital/linktree/assets/53484686/9f681da1-cac5-4db3-bd11-cee023447c21)
